### PR TITLE
Add branch filter for deploy jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,10 @@ workflows:
       - frontend
       - backend
       - deploy_staging:
+          filters:
+            branches:
+              only:
+                -master
           requires:
             - frontend
             - backend
@@ -126,5 +130,9 @@ workflows:
           requires:
             - deploy_staging
       - deploy_production:
+          filters:
+            branches:
+              only:
+                -master
           requires:
             - approval


### PR DESCRIPTION
Deploy only master branch to staging/production.

Staging should be close to production. To stay cost-efficient there are no feature-deployments.