### PR TITLE
Add version information for webpacker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'jwt'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 3.11'
 gem 'rails', '~> 5.2.1'
-gem 'webpacker'
+gem 'webpacker', '~> 3.6.0'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,7 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webpacker (4.0.2)
+    webpacker (3.6.0)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
       railties (>= 4.2)
@@ -251,7 +251,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
   web-console (>= 3.3.0)
-  webpacker
+  webpacker (~> 3.6.0)
 
 RUBY VERSION
    ruby 2.6.0p0


### PR DESCRIPTION
There was an issue with the stylesheet tag not being present when using
webpacker without a specific version (latest at that time: 4.0.2).

A threadpost (https://github.com/rails/webpacker/issues/1659#issuecomment-450974230)
mentioned that locking webpacker to a specific version did the trick.
I tried the same and it DID work.