### PR TITLE
Return default tenant

### DIFF
--- a/app/middleware/user_elevator.rb
+++ b/app/middleware/user_elevator.rb
@@ -1,10 +1,17 @@
 require 'apartment/elevators/generic'
 
 class UserElevator < Apartment::Elevators::Generic
+  DEFAULT_TENANT = 'public'.freeze
+
   def parse_tenant_name(request)
     token = JwtToken.from_request(request)
-    return if token.blank?
+    return DEFAULT_TENANT if token.blank?
 
-    User.find(token.user_id)&.tenant
+    tenant_id = User.find(token.user_id)&.tenant
+    Rails.logger.debug("Identified tenant id #{tenant_id}")
+    tenant_id
+  rescue JWT::DecodeError
+    Rails.logger.warn("Unable to parse jwt token from request #{request}")
+    DEFAULT_TENANT
   end
 end


### PR DESCRIPTION
When the correct tenant could not have been found, we return the current
tenant to ensure that the application does not crash.